### PR TITLE
feat(rest): register /health liveness endpoint via go-grpc-helper v0.16.0 (SP-4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-22
+### Added
+- `/health` liveness endpoint (GET) on the REST gateway
+
+### Changed
+- Upgraded `scanoss/go-grpc-helper` to `v0.16.0`
+
 ## [0.11.0] - 2026-06-02
 ### Added
 - Integrated `go-component-helper` (`componenthelper.GetComponentsVersion`) as the single source of truth for resolving and validating version requirements, querying the same knowledge base (`all_urls`/`versions`/`mines`)
@@ -132,6 +139,7 @@
 - Remove from list those versions that do not contain detections
 - Detailed response status message.
 
+[0.12.0]: https://github.com/scanoss/cryptography/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/scanoss/cryptography/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/scanoss/cryptography/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/scanoss/cryptography/compare/v0.8.1...v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.12.3
 	github.com/scanoss/go-component-helper v0.7.0
-	github.com/scanoss/go-grpc-helper v0.15.1
+	github.com/scanoss/go-grpc-helper v0.16.0
 	github.com/scanoss/go-purl-helper v0.3.0
 	github.com/scanoss/papi v0.41.0
 	github.com/scanoss/zap-logging-helper v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scanoss/go-component-helper v0.7.0 h1:NB0gJdzYQ8kg/UEifAkVnXzdrVT1IaoyipRaYopdsj0=
 github.com/scanoss/go-component-helper v0.7.0/go.mod h1:rvdEl0tRWndm7LeaN1m7iD4QoIryI70fIfzdS+EHylY=
-github.com/scanoss/go-grpc-helper v0.15.1 h1:tiI7JXVj2LYpktkYVqCcUd6XyMi6aVcAKRecNR5QGCA=
-github.com/scanoss/go-grpc-helper v0.15.1/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
+github.com/scanoss/go-grpc-helper v0.16.0 h1:RwFY2iZQ9JQWR0kewBviF1MevfpCBdkijoh+KaYRuEI=
+github.com/scanoss/go-grpc-helper v0.16.0/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
 github.com/scanoss/go-models v0.10.0 h1:x+9XirwTpbLQBj3X9J+D8Lauu0oYB9bxjLafkEMpFtI=
 github.com/scanoss/go-models v0.10.0/go.mod h1:vRSlL4kxtprSwTIAARXVcVZ820tCQfkx6yn6038oY6A=
 github.com/scanoss/go-purl-helper v0.3.0 h1:zH5rcYbmYTvKms2oWrYV+8rWZ2ElLgDIOy2jZ9XhAg0=

--- a/pkg/protocol/rest/server.go
+++ b/pkg/protocol/rest/server.go
@@ -38,6 +38,10 @@ func RunServer(config *myconfig.ServerConfig, ctx context.Context, grpcPort, htt
 	if err != nil {
 		return nil, err
 	}
+	// register the liveness /health endpoint on the gateway mux
+	if err = gw.RegisterHealthEndpoint(mux); err != nil {
+		return nil, err
+	}
 	// Open TCP port (in the background) and listen for requests
 	go func() {
 		ctx2, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
Adds a real GET /health liveness endpoint to the REST gateway by adopting `go-grpc-helper` v0.16.0 (`gw.RegisterHealthEndpoint`).

- Bumps `scanoss/go-grpc-helper` to v0.16.0
- Registers GET /health on the gateway mux in `pkg/protocol/rest/server.go`
- CHANGELOG updated (v0.12.0)

SP-4474 (parent SP-4472).